### PR TITLE
pkmodel labels corrected in command-line...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: GenEst
 Title: Generalized Fatality Estimator
-Version: 0.1.9
+Version: 0.1.10
 Date: 2018-08-29
 Authors@R: c(
     person("Daniel", "Dalthorp", , "ddalthorp@usgs.gov", c("aut", "cre")),
     person("Juniper", "Simonis", , "simonis@dapperstats.com", "aut"),
-    person("Manuela", "Huso", , "mhuso@usgs.gov", "aut"),
     person("Lisa", "Madsen", , "madsenl@oregonstate.edu", "aut"),
+    person("Manuela", "Huso", , "mhuso@usgs.gov", "aut"),
     person("Paul", "Rabie", , "prabie@west-inc.com", "aut"),
     person("Jeffrey", "Mintz", , "mintzj@oregonstate.edu", "aut"),
     person("Robert", "Wolpert", , "wolpert@stat.duke.edu", "aut"),

--- a/R/app_output_update_functions.R
+++ b/R/app_output_update_functions.R
@@ -190,7 +190,7 @@ update_output_run_SE <- function(rv, output, session){
     output$AICcTab_SE <- renderDataTable({rv$AICcTab_SE})    
     output$modTab_SE <- renderDataTable({rv$modTabPretty_SE})
     output$fig_SE <- renderPlot({ 
-                       plot(rv$modSet_SE, specificModel = rv$best_SE, TRUE)
+                       plot(rv$modSet_SE, specificModel = rv$best_SE, app = TRUE)
                      }, height = rv$figH_SE, width = rv$figW_SE)
 
     isolate({
@@ -230,7 +230,7 @@ update_output_outsc_SE <- function(rv, output, session){
     output$AICcTab_SE <- renderDataTable({rv$AICcTab_SE})    
     output$modTab_SE <- renderDataTable({rv$modTabPretty_SE})
     output$fig_SE <- renderPlot({ 
-                       plot(rv$modSet_SE, specificModel = rv$best_SE, TRUE)
+                       plot(rv$modSet_SE, specificModel = rv$best_SE, app = TRUE)
                      }, height = rv$figH_SE, width = rv$figW_SE)
 
     scText <- renderText(paste0("Size class: ", rv$sizeclass_SE))
@@ -263,7 +263,7 @@ update_output_outpk_SE <- function(rv, output, session){
   if (length(rv$mods_SE) > 0){
     output$fig_SE <- renderPlot({ 
                        tryCatch(
-                         plot(rv$modSet_SE, specificModel = rv$outSEpk, TRUE),
+                         plot(rv$modSet_SE, specificModel = rv$outSEpk, app = TRUE),
                          error = function(x){plotNA()}
                        )
                      }, height = rv$figH_SE, width = rv$figW_SE)
@@ -300,7 +300,7 @@ update_output_run_CP <- function(rv, output, session){
     output$AICcTab_CP <- renderDataTable({rv$AICcTab_CP})    
     output$modTab_CP <- renderDataTable({rv$modTabPretty_CP})
     output$fig_CP <- renderPlot({ 
-                       plot(rv$modSet_CP, specificModel = rv$best_CP, TRUE)
+                       plot(rv$modSet_CP, specificModel = rv$best_CP, app = TRUE)
                      }, height = rv$figH_CP, width = rv$figW_CP)
 
     isolate({
@@ -339,7 +339,7 @@ update_output_outsc_CP <- function(rv, output, session){
   if (length(rv$mods_CP) > 0){
     output$modTab_CP <- renderDataTable(rv$modTabPretty_CP)
     output$fig_CP <- renderPlot({ 
-                       plot(rv$modSet_CP, specificModel = rv$best_CP, TRUE)
+                       plot(rv$modSet_CP, specificModel = rv$best_CP, app = TRUE)
                      }, height = rv$figH_CP, width = rv$figW_CP)
 
     scText <- renderText(paste0("Size class: ", rv$sizeclass_CP))
@@ -375,7 +375,7 @@ update_output_outdls_CP <- function(rv, output, session){
     output$modTab_CP <- renderDataTable(rv$modTabPretty_CP)
     output$fig_CP <- renderPlot({ 
                      tryCatch(
-                     plot(rv$modSet_CP, specificModel = rv$outCPdlsfig, TRUE),
+                     plot(rv$modSet_CP, specificModel = rv$outCPdlsfig, app = TRUE),
                      error = function(x){plotNA()}
                      )
                      }, height = rv$figH_CP, width = rv$figW_CP)

--- a/R/searcher_efficiency_functions.R
+++ b/R/searcher_efficiency_functions.R
@@ -817,6 +817,8 @@ pkmSetSize <- function(formula_p, formula_k = NULL, data, obsCol = NULL,
 #' 
 #' @param quiet Logical indicating if messages should be printed
 #' 
+#' @param app Logical indicating if the table should have the app model names
+#'
 #' @return AICc table
 #' 
 #' @examples
@@ -828,7 +830,7 @@ pkmSetSize <- function(formula_p, formula_k = NULL, data, obsCol = NULL,
 #'
 #' @export 
 #'
-pkmSetAICcTab <- function(pkmset, quiet = FALSE){
+pkmSetAICcTab <- function(pkmset, quiet = FALSE, app = FALSE){
 
   nmod <- length(pkmset)
   formulas <- names(pkmset)
@@ -858,6 +860,11 @@ pkmSetAICcTab <- function(pkmset, quiet = FALSE){
     deltaAICc[which_fails] <- NA
   }
 
+  if (app){
+    formulas_p <- gsub("~ 1", "~ constant", formulas_p)
+    formulas_k <- gsub("~ 1", "~ constant", formulas_k)
+  }
+
   output <- data.frame(formulas_p, formulas_k, AICc, deltaAICc)
   output <- output[AICcOrder, ]
   colnames(output) <- c("p Formula", "k Formula", "AICc", "Delta AICc")
@@ -873,7 +880,6 @@ pkmSetAICcTab <- function(pkmset, quiet = FALSE){
   }
   return(output)  # pkmSetAICcTab
 }
-
 #' @title Simulate parameters from a fitted pk model
 #'
 #' @description Simulate parameters from a \code{\link{pkm}} model object

--- a/R/searcher_efficiency_functions.R
+++ b/R/searcher_efficiency_functions.R
@@ -140,7 +140,7 @@
 pkm <- function(formula_p, formula_k = NULL, data, obsCol = NULL,
                 kFixed = NULL, kInit = 0.7, CL = 0.95, quiet = FALSE){
   if (!is.null(kFixed) && is.na(kFixed)) kFixed <- NULL
-  if(sum(obsCol %in% colnames(data)) != length(obsCol)){
+  if(any(! obsCol %in% colnames(data))){
     stop("Observation column provided not in data.")
   }
   if (length(obsCol) == 0){
@@ -186,6 +186,7 @@ pkm <- function(formula_p, formula_k = NULL, data, obsCol = NULL,
       if(is.null(formula_k) || !is.language(formula_k)){
         pOnly <- TRUE
         obsCol <- obsCol[1] # use data from first search only
+        message("p is estimated from data in first search occasion only.")
         formula_k <- NULL
         kFixed <- 1
       }


### PR DESCRIPTION
When length(obsCol) == 1 and kFixed is provided by user, pk model is fit just like it is when length(obsCol) > 1 except that there is no extra information from the extra columns, so p is estimated only from data in the single column. pkm return value for formula_k is now c(kFixed = kFixed) in both cases.

If neither kFixed nor formula_k are provided by user, model for p is fit without any k using ONLY the data in the first obsCol (...several are provided, a warning is given that only the first column is considered). The return value is tagged with output$pOnly = TRUE.

This appears to behave properly on the command-line side, but it breaks on the GUI side.