### PR TITLE
Include area correction variance through DWP bootstrapped samples.

### DIFF
--- a/R/detection_probability_functions.R
+++ b/R/detection_probability_functions.R
@@ -40,9 +40,16 @@
 #'   intervals can greatly increase the speed of calculations with only a 
 #'   slight reduction in accuracy in most cases.
 #'
-#' @return list of [1] g estimates (ghat) and [2] arrival interval estimates 
-#'   (Aj) for each of the carcasses. The row names of the Aj matrix are the
-#'   names of the units where each carcass was found.
+#' @param DWP Density weighted proportion values for each carcass. If
+#'   incorporating area correction variance, \code{DWP} is a matrix with
+#'   nCarcass number of rows and nSim number of columns.
+#'
+#' @return list of [1] g estimates (ghat), [2] arrival interval estimates 
+#'   (Aj) for each of the carcasses, and [3] g estimates multiplied by the
+#'   DWP values (ghatDWP) for each carcass. The row names of the Aj matrix are the
+#'   names of the units where each carcass was found. If incorportating
+#'   area correction variance, \code{ghatDWP} is a matrix nCarcass number of 
+#'   rows and nSim number of columns.
 #'
 #' @examples
 #'  data(mock)
@@ -61,7 +68,12 @@
 estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
                  model_SE, model_CP, sizeCol = NULL, unitCol = NULL,
                  nsim = 1000, max_intervals = 8,
-                 seed_SE = NULL, seed_CP = NULL, seed_g = NULL){
+                 seed_SE = NULL, seed_CP = NULL, seed_g = NULL, DWP = NULL){
+  # error check to confirm nsims and DWP mat are compatible
+  if (!(is.null(DWP)) & !(is.null(dim(DWP)))) {
+    if (ncol(DWP) != nsim) stop("number of DWP reps must equal nsim")
+  }
+  
   i <- sapply(data_CO, is.factor)
   data_CO[i] <- lapply(data_CO[i], as.character)
   i <- sapply(data_SS, is.factor)
@@ -367,7 +379,9 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
   }
 
   rownames(Aj) <- COdat[ , unitCol]
-  out <- list("ghat" = ghat, "Aj" = Aj) # ordered by relevance to user
+  ghatDWP <- ghat * DWP
+  out <- list("ghat" = ghat, "Aj" = Aj, 
+              "ghatDWP" = ghatDWP)  # ordered by relevance to user
   return(out)
 }
 

--- a/R/detection_probability_functions.R
+++ b/R/detection_probability_functions.R
@@ -39,10 +39,17 @@
 #'   consider for each carcass. Optional. Limiting the number of search 
 #'   intervals can greatly increase the speed of calculations with only a 
 #'   slight reduction in accuracy in most cases.
+#'   
+#' @param DWP Density weighted proportion values for each carcass. If
+#'   incorporating area correction variance, \code{DWP} is a matrix with
+#'   nCarcass number of rows and nSim number of columns.
 #'
-#' @return list of [1] g estimates (ghat) and [2] arrival interval estimates 
-#'   (Aj) for each of the carcasses. The row names of the Aj matrix are the
-#'   names of the units where each carcass was found.
+#' @return list of [1] g estimates (ghat), [2] arrival interval estimates 
+#'   (Aj) for each of the carcasses, and [3] g estimates multiplied by the
+#'   DWP values (ghatAC) for each carcass. The row names of the Aj matrix are the
+#'   names of the units where each carcass was found. If incorportating
+#'   area correction variance, \code{ghatAC} is a matrix nCarcass number of 
+#'   rows and nSim number of columns.
 #'
 #' @examples
 #'  data(mock)
@@ -61,13 +68,17 @@
 estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
                  model_SE, model_CP, sizeCol = NULL, unitCol = NULL,
                  nsim = 1000, max_intervals = 8,
-                 seed_SE = NULL, seed_CP = NULL, seed_g = NULL){
+                 seed_SE = NULL, seed_CP = NULL, seed_g = NULL, DWP = NULL){
+  if (!(is.null(DWP)) & !(is.null(dim(DWP)))) {
+    if (ncol(DWP) != nsim) stop("number of DWP reps must equal nsim")
+  }
+  
   i <- sapply(data_CO, is.factor)
   data_CO[i] <- lapply(data_CO[i], as.character)
   i <- sapply(data_SS, is.factor)
   data_SS[i] <- lapply(data_SS[i], as.character)
-
-# error-checking
+  
+  # error-checking
   if (is.null(unitCol))
     unitCol <- defineUnitCol(data_CO = data_CO, data_SS = data_SS)
   SSdat <- prepSS(data_SS) # SSdat name distinguishes this as pre-formatted
@@ -89,8 +100,8 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
   }
   if (anyNA(cind)){
     stop("carcasses discovered at unit(s) ",
-      paste0(data_CO[rind, unitCol], collapse =", "),
-      "in CO...not represented in SS. Cannot estimate g or M.")
+         paste0(data_CO[rind, unitCol], collapse =", "),
+         "in CO...not represented in SS. Cannot estimate g or M.")
   }
   if (any(as.numeric(data_SS[cbind(rind, cind)]) == 0)){
     stop("some carcasses (CO) were found at units that were not searched (SS) ",
@@ -118,16 +129,16 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
   sizeclass <- as.list(as.character(COdat[, sizeCol]))
   sizeclasses <- sort(unique(unlist(sizeclass)))
   nsizeclass <- length(sizeclasses)
-# data pre-processing
-# create lists of arrays for SS (days) and cells (SE and CP)
+  # data pre-processing
+  # create lists of arrays for SS (days) and cells (SE and CP)
   for (sc in sizeclasses){
     if (!("pkm" %in% class(model_SE[[sc]]))){
       stop("Invalid pk model ")
     }
     if (sum(diag(model_SE[[sc]]$varbeta) < 0) > 0){
       stop("
-        Cannot estimate variance in user-supplied pk model for size '", sc,
-        "' Aborting calculation of ghat."
+           Cannot estimate variance in user-supplied pk model for size '", sc,
+           "' Aborting calculation of ghat."
       )
     }
     if (any(unlist(lapply(model_SE, function(x) x$pOnly)))){
@@ -135,7 +146,7 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
       stop("valid k not provided for ", paste(nok, collapse = " "))
     }
   }
-
+  
   preds_SE <- lapply(model_SE, function(x) x$predictors)
   preds_CP <- lapply(model_CP, function(x) x$predictors)
   preds <- mapply(function(x, y) unique(c(x, y)), preds_SE, preds_CP)
@@ -179,14 +190,14 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
       }
     }
   }
-
+  
   #############################################
-
+  
   pksim <- lapply(model_SE, function(x) rpk(nsim, x))
   names(pksim) <- names(model_SE)
-
+  
   cpsim <- lapply(model_CP, rcp, n = nsim, type = "ppersist")
-
+  
   X <- dim(COdat)[1]
   days <- list()
   for (xi in 1:X){
@@ -200,7 +211,7 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
         days[[xi]] <- days[[xi]][(dlen - max_intervals):dlen]
     }
   }
-
+  
   cells <- list()
   # take care of the SS preds
   if (sum(unlist(lapply(SSpreds, length))) == 0){
@@ -222,9 +233,9 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
       }
       cells[[xi]]$CPrep <- length(days[[xi]]) - 1
     }
-
+    
   } else {
-
+    
     for (xi in 1:X){
       cells[[xi]] <- list()
       SEc <- SEr <- CPc <- CPr <- NULL
@@ -242,11 +253,11 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
             ssvec <- (SSdat[[predi]][which(SSdat[["days"]] %in% days[[xi]])])
             ssvec <- ssvec[-1]
             SEc <- paste(SEc, unique(ssvec),
-              sep = ifelse(is.null(SEc), "", "."))
+                         sep = ifelse(is.null(SEc), "", "."))
             SEr <- table(ssvec)[unique(ssvec)]
           } else {
             SEc <- paste(SEc, COdat[xi, predi],
-              sep = ifelse(is.null(SEc), "", "."))
+                         sep = ifelse(is.null(SEc), "", "."))
           }
         }
         cells[[xi]]$SEcell <- SEc
@@ -268,11 +279,11 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
             ssvec <- (SSdat[[predi]][which(SSdat[["days"]] %in% days[[xi]])])
             ssvec <- ssvec[-1]
             CPc <- paste(CPc, unique(ssvec),
-              sep = ifelse(is.null(CPc), "", "."))
+                         sep = ifelse(is.null(CPc), "", "."))
             CPr <- table(ssvec)[unique(ssvec)]
           } else {
             CPc <- paste(CPc, COdat[xi, predi],
-              sep = ifelse(is.null(CPc), "", "."))
+                         sep = ifelse(is.null(CPc), "", "."))
           }
         }
         cells[[xi]]$CPcell <- CPc
@@ -320,12 +331,12 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
         t_search = rep(max(days[[xi]]), length(rng))
       ))
     }
-
+    
     parrive <- diff(days[[xi]][1:(oi+1)])/days[[xi]][oi+1]
     pAjgOi <- t(pOigAj) * parrive; pAjgOi <- t(t(pAjgOi)/colSums(pAjgOi))
     Aj[xi, ] <- # sim arrival intervals (relative to cind's ss)
-       rowSums(matrixStats::rowCumsums(t(pAjgOi)) < runif(nsim)) +
-         (sum(SSxi <= min(days[[xi]])))
+      rowSums(matrixStats::rowCumsums(t(pAjgOi)) < runif(nsim)) +
+      (sum(SSxi <= min(days[[xi]])))
     xuint <- unique(Aj[xi, ]) # unique xi arrival intervals (in SSxi)
     for (aj in xuint){
       # calculate simulated ghat associated with the given carcass and 
@@ -341,7 +352,7 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
       # use an adjusted search schedule because we "know" when carcass arrived
       # which cell is "active" for the given arrival interval?
       cpi <- findInterval(aj, c(0, min(xuint) + cumsum(cells[[xi]]$CPrep)),
-        rightmost.closed = T)
+                          rightmost.closed = T)
       pda <- cpsim[[sz]][[cells[[xi]]$CPcell[cpi]]][simInd , "pda"]
       pdb <- cpsim[[sz]][[cells[[xi]]$CPcell[cpi]]][simInd , "pdb"]
       ppersu <- ppersist(
@@ -353,7 +364,7 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
         t_search = SSxi[(aj + 1):top]
       )
       pki <- findInterval(aj, c(0, min(xuint) + cumsum(cells[[xi]]$SErep)),
-        rightmost.closed = T)
+                          rightmost.closed = T)
       SE <- t(SEsi_right(
         top - aj,
         pksim[[sz]][[cells[[xi]]$SEcell[pki]]][simInd , ]
@@ -365,11 +376,13 @@ estg <- function(data_CO, COdate, data_SS, SSdate = NULL,
       }
     }
   }
-
+  
   rownames(Aj) <- COdat[ , unitCol]
-  out <- list("ghat" = ghat, "Aj" = Aj) # ordered by relevance to user
+  ghatAC <- ghat * DWP
+  out <- list("ghat" = ghat, "Aj" = Aj, 
+              "ghatAC" = ghatAC)  # ordered by relevance to user
   return(out)
-}
+  }
 
 #' @title Calculate conditional probability of observation at a search
 #'
@@ -509,8 +522,8 @@ SEsi_right <- function(nsi, pk){
 #' @export
 #'
 estgGeneric <- function(days, model_SE, model_CP, nsim = 1000, seed_SE = NULL,
-  seed_CP = NULL){
-
+                        seed_CP = NULL){
+  
   if (!is.vector(days) || !is.numeric(days))
     stop(" 'days' must be a numeric vector")
   if (!("pkm" %in% class(model_SE))) stop("Invalid pk model")
@@ -526,7 +539,7 @@ estgGeneric <- function(days, model_SE, model_CP, nsim = 1000, seed_SE = NULL,
   sim_SE <- rpk(n = nsim, model = model_SE)
   sim_CP <- rcp(n = nsim, model = model_CP, type = "ppersist")
   dist <- tolower(model_CP$dist)
-
+  
   ncell <- nrow(preds)
   ghat <- vector("list", ncell)
   for (celli in 1:ncell){
@@ -591,53 +604,53 @@ calcg <- function(days, param_SE, param_CP, dist){
   pk <- param_SE
   f0 <- mean(pk[, 1])
   k0 <- mean(pk[, 2])
-
+  
   if (length(days) == 2){ # then only one search, so it's easy!
     r_sim <- as.vector(ppersist(dist = dist,
-      t_arrive0 = days[1], t_arrive1 = days[2], t_search = days[2],
-      pda = param_CP[,1], pdb = param_CP[,2]))
+                                t_arrive0 = days[1], t_arrive1 = days[2], t_search = days[2],
+                                pda = param_CP[,1], pdb = param_CP[,2]))
     return(r_sim * pk[ , 1])
   }
-
- ###1. setting estimation control parameters
+  
+  ###1. setting estimation control parameters
   ind1 <- rep(1:nsearch, times = nsearch:1)
   ind2 <- ind1 + 1
   ind3 <- unlist(lapply(1:nsearch, function(x) x:nsearch)) + 1
   schedule.index <- cbind(ind1, ind2, ind3)
   schedule <- cbind(days[ind1], days[ind2], days[ind3])
-
+  
   nmiss <- schedule.index[,3] - schedule.index[,2]
   maxmiss <- max(nmiss)
-
+  
   powk <- cumprod(c(1, rep(k0, maxmiss))) 
   notfind <- cumprod(1 - f0*powk[-length(powk)])
   nvec <- c(1, notfind) * f0
-
+  
   # conditional probability of finding a carcass on the ith search (row) after
   # arrival for given (simulated) searcher efficiency (column)
   pfind.si <- nvec * powk
-
+  
   diffs <- cbind(schedule[,2] - schedule[,1], schedule[,3] - schedule[,2])
   intxsearch <- unique(diffs, MAR = 1)
   ppersu <- ppersist(dist = dist, t_arrive0 = 0, t_arrive1 = intxsearch[,1],
-    t_search = intxsearch[,1] + intxsearch[,2], pda = pda0, pdb = pdb0)
+                     t_search = intxsearch[,1] + intxsearch[,2], pda = pda0, pdb = pdb0)
   arrvec <- (schedule[,2] - schedule[,1]) / max(days)
   prob_obs <- numeric(dim(schedule)[1])
   for (i in 1:length(prob_obs)){
     ind <- which(
-               abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
-               abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001
-             )
+      abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
+        abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001
+    )
     prob_obs[i] <- pfind.si[nmiss[i] + 1] * ppersu[ind, ] * arrvec[i]
   }
-
- ###2. estimation of g
- # assumes uniform arrivals
+  
+  ###2. estimation of g
+  # assumes uniform arrivals
   schedule <- schedule[ind2 >= ind3 - maxmiss + 1, ]
   schedule.index <- cbind(ind1, ind2, ind3)[ind2 >= ind3 - maxmiss + 1,]
   nmiss <- schedule.index[ , 3] - schedule.index[ , 2]
   maxmiss <- max(nmiss)
-
+  
   if (maxmiss == 0) {
     pfind.si <- pk[ , 1]
   } else if (maxmiss == 1){
@@ -653,25 +666,25 @@ calcg <- function(days, param_SE, param_CP, dist){
   diffs <- cbind(schedule[,2] - schedule[,1], schedule[,3] - schedule[,2])
   intxsearch <- unique(diffs, MAR = 1)
   ppersu <- ppersist(dist = dist, t_arrive0 = 0, t_arrive1 = intxsearch[ , 1],
-              t_search = intxsearch[ , 1] + intxsearch[ , 2],
-              pda = param_CP[ , 1], pdb = param_CP[ , 2]
-            )
+                     t_search = intxsearch[ , 1] + intxsearch[ , 2],
+                     pda = param_CP[ , 1], pdb = param_CP[ , 2]
+  )
   arrvec <- (schedule[ , 2] - schedule[ , 1]) / max(days)
   prob_obs <- numeric(n)
   if (maxmiss > 0){
     for (i in 1:dim(schedule)[1]){
       ind <- which(
-               abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
-               abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001)
+        abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
+          abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001)
       prob_obs <- prob_obs +
-                  pfind.si[ , nmiss[i] + 1] * ppersu[ind, ] * arrvec[i]
+        pfind.si[ , nmiss[i] + 1] * ppersu[ind, ] * arrvec[i]
     }
   } else {
     for (i in 1:dim(schedule)[1]){
       ind <- which(
-               abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
-               abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001)
-     prob_obs <- prob_obs + pfind.si[nmiss[i] + 1] * ppersu[ind, ] * arrvec[i]
+        abs(intxsearch[,1] - (schedule[i,2] - schedule[i,1])) < 0.001 &
+          abs(intxsearch[,2] - (schedule[i,3] - schedule[i,2])) < 0.001)
+      prob_obs <- prob_obs + pfind.si[nmiss[i] + 1] * ppersu[ind, ] * arrvec[i]
     }
   }
   return(prob_obs)
@@ -752,9 +765,9 @@ calcg <- function(days, param_SE, param_CP, dist){
 #' @export
 #'
 estgGenericSize <- function(days, modelSetSize_SE, modelSetSize_CP,
-    modelSizeSelections_SE, modelSizeSelections_CP,
-    nsim = 1000, seed_SE = NULL, seed_CP = NULL){
-
+                            modelSizeSelections_SE, modelSizeSelections_CP,
+                            nsim = 1000, seed_SE = NULL, seed_CP = NULL){
+  
   if (!("pkmSetSize" %in% class(modelSetSize_SE))){
     stop("modelSetSize_SE must be a pkmSetSize object")
   }
@@ -772,7 +785,7 @@ estgGenericSize <- function(days, modelSetSize_SE, modelSetSize_CP,
   # check whether k is included in every model. If not, error.
   for (sci in sizeclasses){
     if (modelSetSize_SE[[sci]][[modelSizeSelections_SE[sci]]]$pOnly){
-     stop("k required for SE model for size = ", sci)
+      stop("k required for SE model for size = ", sci)
     }
   }
   ghats <- list()
@@ -782,10 +795,10 @@ estgGenericSize <- function(days, modelSetSize_SE, modelSetSize_CP,
     model_SE <- modelSetSize_SE[[sci]][[modelSizeSelections_SE[[sci]]]]
     model_CP <- modelSetSize_CP[[sci]][[modelSizeSelections_CP[[sci]]]]
     ghats[[sci]] <- estgGeneric(nsim = nsim, days = days,
-      model_SE = model_SE, model_CP = model_CP,
-      seed_SE = seed_SE, seed_CP = seed_CP)
+                                model_SE = model_SE, model_CP = model_CP,
+                                seed_SE = seed_SE, seed_CP = seed_CP)
   }
-
+  
   class(ghats) <- c("gGenericSize", "list")
   return(ghats)
 }
@@ -825,7 +838,7 @@ averageSS <- function(data_SS, SSdate = NULL){
   aveSS <- seq(0, max(maxdays), round(mean(maxdays/nintervals)))
   return(aveSS)
 }
-  
+
 #' @title Summarize the gGeneric list to a simple table
 #'
 #' @description methods for \code{summary} applied to a \code{gGeneric} list
@@ -861,16 +874,16 @@ summary.gGeneric <- function(object, ..., CL = 0.90){
   ncell <- length(cells)
   predsByCell <- strsplit(cells, "\\.") 
   npred <- length(predsByCell[[1]])
-
+  
   predsTab <- preds[ , -grep("CellNames", colnames(preds))]
   predsTab <- as.matrix(predsTab, ncol = npred, nrow = ncell)
   predNames <- colnames(preds)[-grep("CellNames", colnames(preds))]
   if (length(predNames) == 1 & predNames[1] == "group" & cells[1] == "all"){
     predNames <- "Group"
   }
-
+  
   tableProbs <- c((1 - CL) / 2, 0.25, 0.5, 0.75, 1 - (1 - CL) / 2)
-
+  
   colnames(predsTab) <- predNames
   gTab <- matrix(NA, ncell, 5)
   for (celli in 1:ncell){
@@ -878,7 +891,7 @@ summary.gGeneric <- function(object, ..., CL = 0.90){
     quants <- quantile(gspec, prob = tableProbs)
     gTab[celli, ] <- round(quants, 3)
   }
-
+  
   out <- data.frame(predsTab, gTab)
   colnames(out)[npred + (1:5)] <- names(quants)
   return(out)
@@ -932,7 +945,7 @@ summary.gGeneric <- function(object, ..., CL = 0.90){
 #' @export
 #'
 summary.gGenericSize <- function(object, ..., CL = 0.90){
-
+  
   sizeclasses <- names(object)
   out <- list()
   for (sci in sizeclasses){

--- a/R/mortality_functions.R
+++ b/R/mortality_functions.R
@@ -10,11 +10,7 @@
 #' @param data_SS Search Schedule data
 #'
 #' @param data_DWP Survey unit (rows) by size (columns) density weighted
-#'   proportion table. Can include an optional \code{rep} column indicating
-#'   the bootstrapped replicate when including area correction variance. If
-#'   including the \code{rep} column, the data frame will have number of rows
-#'   equal to the number of survey units times the number of bootstrapped
-#'   replicates.
+#'   proportion table
 #'
 #' @param frac fraction of facility (by units or by area) surveyed
 #'
@@ -51,8 +47,7 @@
 #' @param max_intervals maximum number of arrival intervals to consider
 #'  for each carcass
 #'
-#' @return list of Mhat, Aj, ghat, DWP (by carcass), and Xtot = total number of
-#'  carcasses observe
+#' @return list of Mhat, Aj, ghat
 #'
 #' @examples 
 #'  \dontrun{
@@ -79,21 +74,21 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
                  unitCol = NULL, SSdate = NULL, sizeCol = NULL,
                  DWPCol = NULL, seed_SE = NULL, seed_CP = NULL, seed_g = NULL,
                  seed_M = NULL, nsim = 1000, max_intervals = 8){
-  
+
   i <- sapply(data_CO, is.factor)
   data_CO[i] <- lapply(data_CO[i], as.character)
   i <- sapply(data_SS, is.factor)
   data_SS[i] <- lapply(data_SS[i], as.character)
   i <- sapply(data_DWP, is.factor)
   data_DWP[i] <- lapply(data_DWP[i], as.character)
-  
+
   if (!(COdate %in% colnames(data_CO))){
     stop("COdate not found in data_CO")
   }
   data_CO[ , COdate] <- checkDate(data_CO[ , COdate])
   if (is.null(data_CO[ , COdate]))
     stop("dates_CO not unambiguously intepretable as dates")
-  
+
   if (is.null(unitCol))
     unitCol <- defineUnitCol(data_CO = data_CO, data_DWP = data_DWP)
   # if no sizeCol is provided, then the later analysis is done without
@@ -114,15 +109,14 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
   }
   # error-checking for match b/t DWP and CO data is done in DWPbyCarcass
   DWP <- DWPbyCarcass(data_DWP = data_DWP, data_CO = data_CO,
-                      sizeCol = sizeCol, unitCol = unitCol, DWPCol = DWPCol)
+           sizeCol = sizeCol, unitCol = unitCol, DWPCol = DWPCol)
   est <- estg(data_CO = data_CO, COdate = COdate,
-              data_SS = data_SS, SSdate = SSdate,
-              model_SE = model_SE, model_CP = model_CP,
-              unitCol = unitCol, sizeCol = sizeCol,
-              nsim = nsim, max_intervals = max_intervals,
-              seed_SE = seed_SE, seed_CP = seed_CP, seed_g = seed_g,
-              DWP = DWP)
-  gDf <- est$ghatAC * frac
+      data_SS = data_SS, SSdate = SSdate,
+      model_SE = model_SE, model_CP = model_CP,
+      unitCol = unitCol, sizeCol = sizeCol,
+      nsim = nsim, max_intervals = max_intervals,
+      seed_SE = seed_SE, seed_CP = seed_CP, seed_g = seed_g)
+  gDf <- est$ghat * DWP * frac
   set.seed(seed_M)
   c_out <- which(rowSums(gDf) == 0)
   if (length(c_out) == 0){
@@ -134,8 +128,7 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
     n <- length(gDf)
     Mhat[-c_out,] <- ((cbinom::rcbinom(n, 1/gDf, gDf)) - (Ecbinom(gDf) - 1))/gDf
   }
-  out <- list(Mhat = Mhat, Aj = est$Aj, ghat = est$ghat, DWP = DWP,
-              Xtot = nrow(data_CO) - length(c_out))
+  out <- list(Mhat = Mhat, Aj = est$Aj, ghat = est$ghat, DWP = DWP, Xtot = nrow(data_CO))
   class(out) <- c("estM", "list")
   return(out)
 }
@@ -147,11 +140,7 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
 #'   they were found
 #'
 #' @param data_DWP Survey unit (rows) by size (columns) density weighted 
-#'   proportion table. Can include an optional \code{rep} column indicating
-#'   the bootstrapped replicate when including area correction variance. If
-#'   including the \code{rep} column, the data frame will have number of rows
-#'   equal to the number of survey units times the number of bootstrapped
-#'   replicates. 
+#'   proportion table 
 #'
 #' @param data_CO Carcass observation data
 #'
@@ -172,9 +161,7 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
 #'  values in (0, 1], that's DWPCol. If there is not a unique column with
 #'  values in (0, 1], an error is returned.
 #'
-#' @return DWP value for each carcass. If incorporating variance in the area
-#'  correction, then a nCarcass by nSims matrix is returned, yielding nSim 
-#'  DWP values for each carcass.
+#' @return DWP value for each carcass 
 #'
 #' @examples 
 #'  data(mock)
@@ -187,189 +174,89 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
 #'
 DWPbyCarcass <- function(data_DWP, data_CO, unitCol = NULL, 
                          sizeCol = NULL, DWPCol = NULL){
-  original_DWP <- data_DWP
-  repName <- "rep"  # col name hard coded for now, could become an arg
-  if (repName %in% colnames(original_DWP)){
-    long_DWP <- original_DWP
-    fullSub <- subset(long_DWP, subset = rep == 1)
-    data_DWP <- fullSub[, -which(colnames(long_DWP) == repName)]
-    rmid <- which(colnames(long_DWP) == unitCol)
-    tmp <- as.numeric(unlist(split(long_DWP[, -rmid], long_DWP$rep)))
-    array_DWP <- array(tmp, dim = c(ncol(data_DWP), nrow(data_DWP), 
-                                    length(unique(long_DWP$rep))))
-    
-    if (is.null(unitCol)){
-      unitCol <- colnames(data_DWP)[colnames(data_DWP) %in% colnames(data_CO)]
-      if (length(unitCol) == 0){
-        stop("data_DWP and data_CO must have identically-named unit columns")
-      }
-      if (length(unitCol) > 1){
-        stop(paste("more than one possibility for unitCol (", unitCol, ")",
-                   collapse = " "))
-      }
-    } else {
-      if (length(unitCol) > 1) stop("length(unitCol) must be 1 if provided")
-      if (!(unitCol %in% colnames(data_DWP))){
-        stop("\"", unitCol, "\" not found in data_DWP")
-      }
+
+  if (is.null(unitCol)){
+    unitCol <- colnames(data_DWP)[colnames(data_DWP) %in% colnames(data_CO)]
+    if (length(unitCol) == 0){
+      stop("data_DWP and data_CO must have identically-named unit columns")
     }
-    # length(unitCol) = 1 and has been found in both CO and DWP;
-    # are all units in data_CO also found in DWP?
-    if (!all(data_CO[, unitCol] %in% data_DWP[ , unitCol])){
-      stop("Some units present in carcass table not in DWP table")
-    } # error-checking on units is complete
-    
-    # parse w.r.t. sizeCol arg and assign DWP to carcasses
-    if (!is.null(sizeCol)){
-      if (!(sizeCol %in% colnames(data_CO))){
-        stop("size class column not found in carcass data.")
+    if (length(unitCol) > 1){
+      stop(paste("more than one possibility for unitCol (", unitCol, ")",
+        collapse = " "))
+    }
+  } else {
+    if (length(unitCol) > 1) stop("length(unitCol) must be 1 if provided")
+    if (!(unitCol %in% colnames(data_DWP))){
+      stop("\"", unitCol, "\" not found in data_DWP")
+    }
+  }
+  # length(unitCol) = 1 and has been found in both CO and DWP;
+  # are all units in data_CO also found in DWP?
+  if (!all(data_CO[, unitCol] %in% data_DWP[ , unitCol])){
+    stop("Some units present in carcass table not in DWP table")
+  } # error-checking on units is complete
+
+  # parse w.r.t. sizeCol arg and assign DWP to carcasses
+  if (!is.null(sizeCol)){
+    if (!(sizeCol %in% colnames(data_CO))){
+      stop("size class column not found in carcass data.")
+    }
+    if (!all(unique(data_CO[,sizeCol]) %in% colnames(data_DWP))){
+      stop("not all sizes in data_CO are represented in data_DWP.")
+    }
+    # size classes and units have been error-checked, and assigning DWP to
+    #  carcasses is a simple extraction of DWP from the appropriate row and
+    #  column for each carcass in CO.
+    # unit in CO defines the desired row in DWP:
+    rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
+    # size in CO defines the desired column in DWP:
+    colind <- match(data_CO[ , sizeCol], names(data_DWP))
+    # and DWPbyCarc falls out naturally
+    DWPbyCarc <- as.numeric(data_DWP[cbind(rowind, colind)])
+    if (!is.null(DWPCol) && !is.na(DWPCol)){
+      message("\nBoth sizeCol and DWPCol were provided by user. ",
+        "Assigning DWP by size.\n")
+    }
+  } else { # assume same DWP for all sizes, so matching is by unit only
+    # which column has the DWP data?
+    if (!is.null(DWPCol)){
+      # DWPCol has been provided, but must be error-checked (as below)
+      if (length(DWPCol) > 1 || !is.character(DWPCol)){
+        stop("DWPCol must be the name of a single column in data_DWP or NULL")
       }
-      if (!all(unique(data_CO[,sizeCol]) %in% colnames(data_DWP))){
-        stop("not all sizes in data_CO are represented in data_DWP.")
+      if (!(DWPCol %in% colnames(data_DWP))){
+        stop("DWPCol must be the name of column in data_DWP or NULL")
       }
-      # size classes and units have been error-checked, and assigning DWP to
-      #  carcasses is a simple extraction of DWP from the appropriate row and
-      #  column for each carcass in CO.
-      # unit in CO defines the desired row in DWP:
+      if (!is.numeric(data_DWP[ , DWPCol]) || anyNA(data_DWP[ , DWPCol])){
+        stop("data_DWP[, DWPCol] must be numeric with no NA's")
+      }
+      if (sum(data_DWP[, DWPCol] <= 0 | data_DWP[, DWPCol] > 1) > 0){
+        stop("data_DWP[, DWPCol] values must be in (0, 1]")
+      }
       rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-      # size in CO defines the desired column in DWP:
-      colind <- match(data_CO[ , sizeCol], names(data_DWP))
-      # and DWPbyCarc falls out naturally
-      DWPbyCarc <- apply(array_DWP, 3, 
-                         function(x, ri, ci){x[ri + nrow(x) * ((ci-2))]},
-                         ri = rowind, ci = colind)
-      if (!is.null(DWPCol) && !is.na(DWPCol)){
-        message("\nBoth sizeCol and DWPCol were provided by user. ",
-                "Assigning DWP by size.\n")
-      }
-    } else { # assume same DWP for all sizes, so matching is by unit only
-      # which column has the DWP data?
-      if (!is.null(DWPCol)){
-        # DWPCol has been provided, but must be error-checked (as below)
-        if (length(DWPCol) > 1 || !is.character(DWPCol)){
-          stop("DWPCol must be the name of a single column in data_DWP or NULL")
-        }
-        if (!(DWPCol %in% colnames(data_DWP))){
-          stop("DWPCol must be the name of column in data_DWP or NULL")
-        }
-        if (!is.numeric(data_DWP[ , DWPCol]) || anyNA(data_DWP[ , DWPCol])){
-          stop("data_DWP[, DWPCol] must be numeric with no NA's")
-        }
-        if (sum(data_DWP[, DWPCol] <= 0 | data_DWP[, DWPCol] > 1) > 0){
-          stop("data_DWP[, DWPCol] values must be in (0, 1]")
-        }
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- array_DWP[rowind, DWPCol, ]
-      } else {
-        possibleNames <- colnames(data_DWP)
-        for (coli in possibleNames){
-          if (is.numeric(data_DWP[ , coli]) && !anyNA(data_DWP[ , coli]) &&
-              all(data_DWP[ , coli] <= 1) && all(data_DWP[ , coli] > 0)){
-            # candidate DWP has been discovered
-            if (is.null(DWPCol)){
-              DWPCol <- coli
-            } else { # it is the second one found => conflict
-              stop(
-                "data_DWP must have columns corresponding to data_CO sizes\n",
-                "or have a single column of DWP's to associate with units.\n",
-                "Alternatively, user may specify name of DWP column as DWPCol"
-              )
-            }
+      DWPbyCarc <- data_DWP[rowind, DWPCol]
+    } else {
+      possibleNames <- colnames(data_DWP)
+      for (coli in possibleNames){
+        if (is.numeric(data_DWP[ , coli]) && !anyNA(data_DWP[ , coli]) &&
+            all(data_DWP[ , coli] <= 1) && all(data_DWP[ , coli] > 0)){
+          # candidate DWP has been discovered
+          if (is.null(DWPCol)){
+            DWPCol <- coli
+          } else { # it is the second one found => conflict
+            stop(
+              "data_DWP must have columns corresponding to data_CO sizes\n",
+              "or have a single column of DWP's to associate with units.\n",
+              "Alternatively, user may specify name of DWP column as DWPCol"
+            )
           }
         }
-        # DWPCol and unitCol have been error-checked, so
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- as.numeric(array_DWP[rowind, DWPCol, ])
       }
-    }
-  }  # end if for the area correction variance
-  
-  if(!("rep" %in% colnames(original_DWP))){
-    data_DWP <- original_DWP
-    
-    if (is.null(unitCol)){
-      unitCol <- colnames(data_DWP)[colnames(data_DWP) %in% colnames(data_CO)]
-      if (length(unitCol) == 0){
-        stop("data_DWP and data_CO must have identically-named unit columns")
-      }
-      if (length(unitCol) > 1){
-        stop(paste("more than one possibility for unitCol (", unitCol, ")",
-                   collapse = " "))
-      }
-    } else {
-      if (length(unitCol) > 1) stop("length(unitCol) must be 1 if provided")
-      if (!(unitCol %in% colnames(data_DWP))){
-        stop("\"", unitCol, "\" not found in data_DWP")
-      }
-    }
-    # length(unitCol) = 1 and has been found in both CO and DWP;
-    # are all units in data_CO also found in DWP?
-    if (!all(data_CO[, unitCol] %in% data_DWP[ , unitCol])){
-      stop("Some units present in carcass table not in DWP table")
-    } # error-checking on units is complete
-    
-    # parse w.r.t. sizeCol arg and assign DWP to carcasses
-    if (!is.null(sizeCol)){
-      if (!(sizeCol %in% colnames(data_CO))){
-        stop("size class column not found in carcass data.")
-      }
-      if (!all(unique(data_CO[,sizeCol]) %in% colnames(data_DWP))){
-        stop("not all sizes in data_CO are represented in data_DWP.")
-      }
-      # size classes and units have been error-checked, and assigning DWP to
-      #  carcasses is a simple extraction of DWP from the appropriate row and
-      #  column for each carcass in CO.
-      # unit in CO defines the desired row in DWP:
+      # DWPCol and unitCol have been error-checked, so
       rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-      # size in CO defines the desired column in DWP:
-      colind <- match(data_CO[ , sizeCol], names(data_DWP))
-      # and DWPbyCarc falls out naturally
-      DWPbyCarc <- as.numeric(data_DWP[cbind(rowind, colind)])
-      if (!is.null(DWPCol) && !is.na(DWPCol)){
-        message("\nBoth sizeCol and DWPCol were provided by user. ",
-                "Assigning DWP by size.\n")
-      }
-    } else { # assume same DWP for all sizes, so matching is by unit only
-      # which column has the DWP data?
-      if (!is.null(DWPCol)){
-        # DWPCol has been provided, but must be error-checked (as below)
-        if (length(DWPCol) > 1 || !is.character(DWPCol)){
-          stop("DWPCol must be the name of a single column in data_DWP or NULL")
-        }
-        if (!(DWPCol %in% colnames(data_DWP))){
-          stop("DWPCol must be the name of column in data_DWP or NULL")
-        }
-        if (!is.numeric(data_DWP[ , DWPCol]) || anyNA(data_DWP[ , DWPCol])){
-          stop("data_DWP[, DWPCol] must be numeric with no NA's")
-        }
-        if (sum(data_DWP[, DWPCol] <= 0 | data_DWP[, DWPCol] > 1) > 0){
-          stop("data_DWP[, DWPCol] values must be in (0, 1]")
-        }
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- data_DWP[rowind, DWPCol]
-      } else {
-        possibleNames <- colnames(data_DWP)
-        for (coli in possibleNames){
-          if (is.numeric(data_DWP[ , coli]) && !anyNA(data_DWP[ , coli]) &&
-              all(data_DWP[ , coli] <= 1) && all(data_DWP[ , coli] > 0)){
-            # candidate DWP has been discovered
-            if (is.null(DWPCol)){
-              DWPCol <- coli
-            } else { # it is the second one found => conflict
-              stop(
-                "data_DWP must have columns corresponding to data_CO sizes\n",
-                "or have a single column of DWP's to associate with units.\n",
-                "Alternatively, user may specify name of DWP column as DWPCol"
-              )
-            }
-          }
-        }
-        # DWPCol and unitCol have been error-checked, so
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- as.numeric(data_DWP[rowind, DWPCol])
-      }
+      DWPbyCarc <- as.numeric(data_DWP[rowind, DWPCol])
     }
-  }  # end if for NO area correction variance
+  }
   return(DWPbyCarc)
 }
 
@@ -393,3 +280,4 @@ summary.estM <- function(object, ..., CL = 0.90){
   names(out) <- c("median", paste0(100*c(alpha/2, 1- alpha/2), "%"))
   return(out)
 }
+

--- a/R/mortality_functions.R
+++ b/R/mortality_functions.R
@@ -184,6 +184,92 @@ estM <- function(data_CO, data_SS, data_DWP, frac = 1,
 DWPbyCarcass <- function(data_DWP, data_CO, unitCol = NULL, 
                          sizeCol = NULL, DWPCol = NULL){
   
+  if(!("rep" %in% colnames(original_DWP))){
+    data_DWP <- original_DWP
+    if (is.null(unitCol)){
+      unitCol <- colnames(data_DWP)[colnames(data_DWP) %in% colnames(data_CO)]
+      if (length(unitCol) == 0){
+        stop("data_DWP and data_CO must have identically-named unit columns")
+      }
+      if (length(unitCol) > 1){
+        stop(paste("more than one possibility for unitCol (", unitCol, ")",
+          collapse = " "))
+      }
+    } else {
+      if (length(unitCol) > 1) stop("length(unitCol) must be 1 if provided")
+      if (!(unitCol %in% colnames(data_DWP))){
+        stop("\"", unitCol, "\" not found in data_DWP")
+      }
+    }
+    # length(unitCol) = 1 and has been found in both CO and DWP;
+    # are all units in data_CO also found in DWP?
+    if (!all(data_CO[, unitCol] %in% data_DWP[ , unitCol])){
+      stop("Some units present in carcass table not in DWP table")
+    } # error-checking on units is complete
+  
+    # parse w.r.t. sizeCol arg and assign DWP to carcasses
+    if (!is.null(sizeCol)){
+      if (!(sizeCol %in% colnames(data_CO))){
+        stop("size class column not found in carcass data.")
+      }
+      if (!all(unique(data_CO[,sizeCol]) %in% colnames(data_DWP))){
+        stop("not all sizes in data_CO are represented in data_DWP.")
+      }
+      # size classes and units have been error-checked, and assigning DWP to
+      #  carcasses is a simple extraction of DWP from the appropriate row and
+      #  column for each carcass in CO.
+      # unit in CO defines the desired row in DWP:
+      rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
+      # size in CO defines the desired column in DWP:
+      colind <- match(data_CO[ , sizeCol], names(data_DWP))
+      # and DWPbyCarc falls out naturally
+      DWPbyCarc <- as.numeric(data_DWP[cbind(rowind, colind)])
+      if (!is.null(DWPCol) && !is.na(DWPCol)){
+        message("\nBoth sizeCol and DWPCol were provided by user. ",
+          "Assigning DWP by size.\n")
+      }
+    } else { # assume same DWP for all sizes, so matching is by unit only
+      # which column has the DWP data?
+      if (!is.null(DWPCol)){
+        # DWPCol has been provided, but must be error-checked (as below)
+        if (length(DWPCol) > 1 || !is.character(DWPCol)){
+          stop("DWPCol must be the name of a single column in data_DWP or NULL")
+        }
+        if (!(DWPCol %in% colnames(data_DWP))){
+          stop("DWPCol must be the name of column in data_DWP or NULL")
+        }
+        if (!is.numeric(data_DWP[ , DWPCol]) || anyNA(data_DWP[ , DWPCol])){
+          stop("data_DWP[, DWPCol] must be numeric with no NA's")
+        }
+        if (sum(data_DWP[, DWPCol] <= 0 | data_DWP[, DWPCol] > 1) > 0){
+          stop("data_DWP[, DWPCol] values must be in (0, 1]")
+        }
+        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
+        DWPbyCarc <- data_DWP[rowind, DWPCol]
+      } else {
+        possibleNames <- colnames(data_DWP)
+        for (coli in possibleNames){
+          if (is.numeric(data_DWP[ , coli]) && !anyNA(data_DWP[ , coli]) &&
+              all(data_DWP[ , coli] <= 1) && all(data_DWP[ , coli] > 0)){
+            # candidate DWP has been discovered
+            if (is.null(DWPCol)){
+              DWPCol <- coli
+            } else { # it is the second one found => conflict
+              stop(
+                "data_DWP must have columns corresponding to data_CO sizes\n",
+                "or have a single column of DWP's to associate with units.\n",
+                "Alternatively, user may specify name of DWP column as DWPCol"
+              )
+            }
+          }
+        }
+        # DWPCol and unitCol have been error-checked, so
+        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
+        DWPbyCarc <- as.numeric(data_DWP[rowind, DWPCol])
+      }
+    }
+  }  # end if for NO area correction variance
+  
   original_DWP <- data_DWP
   repName <- "rep"  # col name hard coded for now, could become an arg
   if (repName %in% colnames(original_DWP)){
@@ -281,91 +367,6 @@ DWPbyCarcass <- function(data_DWP, data_CO, unitCol = NULL,
     }
   }  # end if for the area correction variance
   
-  if(!("rep" %in% colnames(original_DWP))){
-    data_DWP <- original_DWP
-    if (is.null(unitCol)){
-      unitCol <- colnames(data_DWP)[colnames(data_DWP) %in% colnames(data_CO)]
-      if (length(unitCol) == 0){
-        stop("data_DWP and data_CO must have identically-named unit columns")
-      }
-      if (length(unitCol) > 1){
-        stop(paste("more than one possibility for unitCol (", unitCol, ")",
-          collapse = " "))
-      }
-    } else {
-      if (length(unitCol) > 1) stop("length(unitCol) must be 1 if provided")
-      if (!(unitCol %in% colnames(data_DWP))){
-        stop("\"", unitCol, "\" not found in data_DWP")
-      }
-    }
-    # length(unitCol) = 1 and has been found in both CO and DWP;
-    # are all units in data_CO also found in DWP?
-    if (!all(data_CO[, unitCol] %in% data_DWP[ , unitCol])){
-      stop("Some units present in carcass table not in DWP table")
-    } # error-checking on units is complete
-  
-    # parse w.r.t. sizeCol arg and assign DWP to carcasses
-    if (!is.null(sizeCol)){
-      if (!(sizeCol %in% colnames(data_CO))){
-        stop("size class column not found in carcass data.")
-      }
-      if (!all(unique(data_CO[,sizeCol]) %in% colnames(data_DWP))){
-        stop("not all sizes in data_CO are represented in data_DWP.")
-      }
-      # size classes and units have been error-checked, and assigning DWP to
-      #  carcasses is a simple extraction of DWP from the appropriate row and
-      #  column for each carcass in CO.
-      # unit in CO defines the desired row in DWP:
-      rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-      # size in CO defines the desired column in DWP:
-      colind <- match(data_CO[ , sizeCol], names(data_DWP))
-      # and DWPbyCarc falls out naturally
-      DWPbyCarc <- as.numeric(data_DWP[cbind(rowind, colind)])
-      if (!is.null(DWPCol) && !is.na(DWPCol)){
-        message("\nBoth sizeCol and DWPCol were provided by user. ",
-          "Assigning DWP by size.\n")
-      }
-    } else { # assume same DWP for all sizes, so matching is by unit only
-      # which column has the DWP data?
-      if (!is.null(DWPCol)){
-        # DWPCol has been provided, but must be error-checked (as below)
-        if (length(DWPCol) > 1 || !is.character(DWPCol)){
-          stop("DWPCol must be the name of a single column in data_DWP or NULL")
-        }
-        if (!(DWPCol %in% colnames(data_DWP))){
-          stop("DWPCol must be the name of column in data_DWP or NULL")
-        }
-        if (!is.numeric(data_DWP[ , DWPCol]) || anyNA(data_DWP[ , DWPCol])){
-          stop("data_DWP[, DWPCol] must be numeric with no NA's")
-        }
-        if (sum(data_DWP[, DWPCol] <= 0 | data_DWP[, DWPCol] > 1) > 0){
-          stop("data_DWP[, DWPCol] values must be in (0, 1]")
-        }
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- data_DWP[rowind, DWPCol]
-      } else {
-        possibleNames <- colnames(data_DWP)
-        for (coli in possibleNames){
-          if (is.numeric(data_DWP[ , coli]) && !anyNA(data_DWP[ , coli]) &&
-              all(data_DWP[ , coli] <= 1) && all(data_DWP[ , coli] > 0)){
-            # candidate DWP has been discovered
-            if (is.null(DWPCol)){
-              DWPCol <- coli
-            } else { # it is the second one found => conflict
-              stop(
-                "data_DWP must have columns corresponding to data_CO sizes\n",
-                "or have a single column of DWP's to associate with units.\n",
-                "Alternatively, user may specify name of DWP column as DWPCol"
-              )
-            }
-          }
-        }
-        # DWPCol and unitCol have been error-checked, so
-        rowind <- match(data_CO[, unitCol], data_DWP[, unitCol])
-        DWPbyCarc <- as.numeric(data_DWP[rowind, DWPCol])
-      }
-    }
-  }  # end if for NO area correction variance
   return(DWPbyCarc)
 }
 


### PR DESCRIPTION
The changes allow the user to include area correction variance by altering the data_DWP input such that it contains bootstrapped samples for each unit and size combination (as and if specified by the user). In the diff comparisons it will look like a large section of ```DWPbyCarcass()``` was deleted but a large chunk was actually just copied and put inside a big if/then statement. No original code was deleted. The biggest change to plain vanilla GenEst is in the ```estg()``` function, which now returns the g estimates already multiplied by DWP. Thus, in ```estM()``` the final g estimates  are calculated as ```gDf <- est$ghatDWP * frac```. Note that this change does not affect default behavior. 

I have tested these changes, but testing from a third party is necessary to hunt down any lingering edge-case bugs.